### PR TITLE
ssc2museca converter, 16-lane note format paired with a custom StepMania 5.2 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__
 .mypy_cache
 *.def
 *.2dx
+*.dll
+*.exe
+*.mp3
+*.wav
+*.ogg

--- a/audio.py
+++ b/audio.py
@@ -121,7 +121,7 @@ class ADPCM:
 
         # We must create a temporary file, use ffmpeg to convert the file
         # to MS-ADPCM and then load those bytes in.
-        with tempfile.NamedTemporaryFile(suffix='.wav') as temp:
+        with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as temp:
             subprocess.call([
                 'ffmpeg',
                 '-y',
@@ -140,6 +140,7 @@ class ADPCM:
 
             temp.seek(0)
             self.__full_data = temp.read()
+        os.remove(temp.name)
 
     def __conv_preview(self) -> None:
         self.__check_file()
@@ -148,7 +149,7 @@ class ADPCM:
 
         # We have to convert to .wav because SOX sometimes doesn't have
         # codecs for other formats, so we support everything ffmpeg does.
-        with tempfile.NamedTemporaryFile(suffix='.wav') as intemp:
+        with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as intemp:
             subprocess.call([
                 'ffmpeg',
                 '-y',
@@ -162,7 +163,7 @@ class ADPCM:
             ])
 
             # Now, get sox to cut this up into a new file.
-            with tempfile.NamedTemporaryFile(suffix='.wav') as cuttemp:
+            with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as cuttemp:
                 subprocess.call([
                     'sox',
                     '-V1',
@@ -184,7 +185,7 @@ class ADPCM:
                 ])
 
                 # Now, do the final conversion to ADPCM and load the data.
-                with tempfile.NamedTemporaryFile(suffix='.wav') as outtemp:
+                with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as outtemp:
                     subprocess.call([
                         'ffmpeg',
                         '-y',
@@ -203,6 +204,9 @@ class ADPCM:
 
                     outtemp.seek(0)
                     self.__preview_data = outtemp.read()
+                os.remove(outtemp.name)
+            os.remove(cuttemp.name)
+        os.remove(intemp.name)
 
     def get_full_data(self) -> bytes:
         if self.__full_data is None:

--- a/chartv2.py
+++ b/chartv2.py
@@ -393,6 +393,31 @@ class Chartv2:
                 'end': int(end),
             }
 
+        # read (sorted) labels list and pick out relevant GRAFICA_ entries
+        def parse_grafica():
+            relevant_labels = [l for l in labels if l[2].startswith('GRAFICA_')]
+            if len(relevant_labels) < 6:
+                raise Exception('Not enough GRAFICA_ items found in #LABELS, need 6!');
+            for i, (time, beat, label) in enumerate(relevant_labels):
+                if label != Constants.GRAFICA_LABELS[i]:
+                    raise Exception(
+                        'Unexpected {} label found in #LABELS, was expecting {}.'.format(label, Constants.GRAFICA_LABELS[i])
+                    )
+                else:
+                    if i % 2 == 0:
+                        event_type = Constants.EVENT_KIND_GRAFICA_SECTION_START
+                    else:
+                        event_type = Constants.EVENT_KIND_GRAFICA_SECTION_END
+
+                    events.append(event(
+                        event_type,
+                        event_type,
+                        time,
+                        time
+                    ))
+
+        parse_grafica()
+
         def parse_measure(curtime: float, measure: List[Tuple[int, str]]) -> float:
             # First, get the BPM of this measure, and the divisor for the measure.
             bpm = get_cur_bpm(curtime)

--- a/chartv2.py
+++ b/chartv2.py
@@ -156,7 +156,6 @@ class Chartv2:
                     if i == len(self.bpms[1:]) and target_beat > cur_beat:
                         total_ms += __single_section_ms((target_beat - cur_beat), float(cur_bpm))
 
-
                     prev_beat = cur_beat
                     prev_bpm = cur_bpm
 
@@ -194,14 +193,13 @@ class Chartv2:
         # Data we're building up about the current section
         cursection = {}  # type: Dict[str, Any]
 
-
         # Whether we're in a section or not.
         section = False
 
         # #NOTEDATA
         notedata_section = False
 
-        # Whether we're in the #NOTES section which contains the measures
+        # Whether we're in the #NOTES section which contains the actual measures
         notes_section = False
 
         # #BPMS
@@ -466,9 +464,6 @@ class Chartv2:
                 if len(mset) > 0 and len(mset) != len(Constants.SM_LANES):
                     raise Exception('Invalid measure data on line {}!'.format(lineno))
 
-                # if a mine is found, ignore mines anywhere else on the line
-                storm_ended = False
-
                 ## TRULY WHERE IT BEGINS ##
                 ## ...and also truly where it needs to be refactored ##
                 for msc_lane, sm_lanes in enumerate(Constants.MSC_LANES):
@@ -480,6 +475,9 @@ class Chartv2:
 
                     # hold is ending, check pending_events and push an event
                     resolving_pending = False
+
+                    # if a mine is found, ignore mines anywhere else in this channel
+                    storm_ended = False
 
                     # note data for this channel: ['1', '0', '0']
                     # (or just a single ['0'] for pedal lane)
@@ -562,12 +560,12 @@ class Chartv2:
                                 pending_events.append((
                                 lineno,
                                 event(
-                                    event_type,
-                                    msc_lane,
-                                    curtime,
-                                    curtime,
-                                )
-                            ))
+                                        event_type,
+                                        msc_lane,
+                                        curtime,
+                                        curtime,
+                                    )
+                                ))
                             else: # both spin items are taps
                                 event_type = Constants.EVENT_KIND_SMALL_SPINNER
                                 events.append(event(
@@ -601,7 +599,7 @@ class Chartv2:
                                     ))
                                 elif spins[0] not in Constants.SM_NOTES:
                                     invalid_note_found = True
-                            elif spins[1] != Constants.SM_NOTE_NONE: # spin right
+                            if spins[1] != Constants.SM_NOTE_NONE: # spin right
                                 if spins[1] == Constants.SM_NOTE_TAP:
                                     event_type = Constants.EVENT_KIND_SMALL_SPINNER_RIGHT
                                     events.append(event(
@@ -886,8 +884,8 @@ class XMLv2:
         element(info, 'bpm_max', str(int(maxbpm * 100))).setAttribute('__type', 'u32')
         element(info, 'distribution_date', datetime.date.strftime(datetime.datetime.now(), "%Y%m%d")).setAttribute('__type', 'u32')  # type: ignore
 
-        # TODO: Figure out what some of these should be
-        element(info, 'volume', '75').setAttribute('__type', 'u16')
+        # TODO: Figure out what more of these should be (is_fixed???)
+        element(info, 'volume', '90').setAttribute('__type', 'u16')
         element(info, 'bg_no', '0').setAttribute('__type', 'u16')
         element(info, 'genre', '16').setAttribute('__type', 'u8')
         element(info, 'is_fixed', '1').setAttribute('__type', 'u8')

--- a/chartv2.py
+++ b/chartv2.py
@@ -1,0 +1,806 @@
+import argparse
+import datetime
+import os
+import sys
+
+from typing import Dict, Any, List, Tuple, Optional
+from xml.dom import minidom  # type: ignore
+
+class Constants:
+    EVENT_KIND_NOTE = 0
+    EVENT_KIND_HOLD = 1
+    EVENT_KIND_LARGE_SPINNER = 2
+    EVENT_KIND_LARGE_SPINNER_LEFT = 3
+    EVENT_KIND_LARGE_SPINNER_RIGHT = 4
+    EVENT_KIND_SMALL_SPINNER = 5
+    EVENT_KIND_SMALL_SPINNER_LEFT = 6
+    EVENT_KIND_SMALL_SPINNER_RIGHT = 7
+
+    EVENT_KIND_MEASURE_MARKER = 11
+    EVENT_KIND_BEAT_MARKER = 12
+
+    EVENT_KIND_GRAFICA_SECTION_START = 14
+    EVENT_KIND_GRAFICA_SECTION_END = 15
+
+    EVENT_CATEGORY_LARGE_SPINNERS = [EVENT_KIND_LARGE_SPINNER,
+                                     EVENT_KIND_LARGE_SPINNER_LEFT,
+                                     EVENT_KIND_LARGE_SPINNER_RIGHT]
+
+    # CONSTANTS FOR 16-LANE FORMAT
+    # (these may not all get used)
+    SM_LANE_PEDAL = 0
+    SM_LANE_1  = 1
+    SM_LANE_2  = 2
+    SM_LANE_3  = 3
+    SM_LANE_4  = 4
+    SM_LANE_5  = 5
+    SM_LANE_1L = 6
+    SM_LANE_2L = 7
+    SM_LANE_3L = 8
+    SM_LANE_4L = 9
+    SM_LANE_5L = 10
+    SM_LANE_1R = 11
+    SM_LANE_2R = 12
+    SM_LANE_3R = 13
+    SM_LANE_4R = 14
+    SM_LANE_5R = 15
+
+    # STEPMANIA LANE LIST (basically the same as [0,15])
+    # used for checking line length, potentially other things
+    SM_LANES = [SM_LANE_PEDAL,
+                SM_LANE_1, SM_LANE_2, SM_LANE_3, SM_LANE_4, SM_LANE_5,
+                SM_LANE_1L, SM_LANE_2L, SM_LANE_3L, SM_LANE_4L, SM_LANE_5L,
+                SM_LANE_1R, SM_LANE_2R, SM_LANE_3R, SM_LANE_4R, SM_LANE_5R]
+
+    # STEPMANIA NOTE TYPES
+    # - only taps, hold starts, hold ends, and mines are in the spec
+    SM_NOTE_NONE = '0'
+    SM_NOTE_TAP = '1'
+    SM_NOTE_HOLD_START = '2'
+    SM_NOTE_HOLD_END = '3'
+    SM_NOTE_MINE = 'M'
+    SM_NOTES = [SM_NOTE_NONE, SM_NOTE_TAP, SM_NOTE_HOLD_START, SM_NOTE_HOLD_END, SM_NOTE_MINE]
+    SM_ACTUAL_NOTES = [SM_NOTE_TAP, SM_NOTE_HOLD_START, SM_NOTE_HOLD_END, SM_NOTE_MINE]
+
+    ## CHANNELS ##
+    # - interpret taps and holds in CH1 as normal
+    # - interpret taps in CH2 or CH3 as spins or storms
+    SM_CH1 = [SM_LANE_1, SM_LANE_2, SM_LANE_3, SM_LANE_4, SM_LANE_5]
+    SM_CH2 = [SM_LANE_1L, SM_LANE_2L, SM_LANE_3L, SM_LANE_4L, SM_LANE_5L]
+    SM_CH3 = [SM_LANE_1R, SM_LANE_2R, SM_LANE_3R, SM_LANE_4R, SM_LANE_5R]
+    SM_CHS = [SM_CH1, SM_CH2, SM_CH3]
+
+    ## MUSECA LANES ##
+    # - this is where the player should see them in-game
+    # - if a mine is in any of these, end a storm object
+    MSC_LANE_1 = [SM_LANE_1, SM_LANE_1L, SM_LANE_1R]
+    MSC_LANE_2 = [SM_LANE_2, SM_LANE_2L, SM_LANE_2R]
+    MSC_LANE_3 = [SM_LANE_3, SM_LANE_3L, SM_LANE_3R]
+    MSC_LANE_4 = [SM_LANE_4, SM_LANE_4L, SM_LANE_4R]
+    MSC_LANE_5 = [SM_LANE_5, SM_LANE_5L, SM_LANE_5R]
+    MSC_LANES = [MSC_LANE_1, MSC_LANE_2, MSC_LANE_3, MSC_LANE_4, MSC_LANE_5, [SM_LANE_PEDAL]]
+
+    ### SPIN LANES ###
+    # - if a tap is in both entries, make a non-directional spin
+    # - if a hold start is in either entry, start a storm object
+    MSC_SPIN_1 = [SM_LANE_1L, SM_LANE_1R]
+    MSC_SPIN_2 = [SM_LANE_2L, SM_LANE_2R]
+    MSC_SPIN_3 = [SM_LANE_3L, SM_LANE_3R]
+    MSC_SPIN_4 = [SM_LANE_4L, SM_LANE_4R]
+    MSC_SPIN_5 = [SM_LANE_5L, SM_LANE_5R]
+    MSC_SPINS = [MSC_SPIN_1, MSC_SPIN_2, MSC_SPIN_3, MSC_SPIN_4, MSC_SPIN_5]
+
+
+# This works similarly to the original sm2museca chart class, except for the part
+# where it doesn't. This uses a custom game mode with a 16-lane game type,
+# allowing for easier graphical editing of charts, wtih a hopefully easier
+# conversion process, without breaking the .sm format while still supporting
+# most of the special things that make Museca charts Museca charts.
+# (read: simultaneous events)
+class Chartv2:
+
+    def __init__(self, data: bytes) -> None:
+        self.metadata = self.__get_metadata(data)
+        self.notes = self.__get_notesections(data)
+        self.events = {}  # type: Dict[str, List[Dict[str, int]]]
+        for difficulty in ['easy', 'medium', 'hard']:
+            if difficulty not in self.notes:
+                continue
+            self.events[difficulty] = self.__get_events(difficulty, self.notes[difficulty])
+
+    def __get_metadata(self, data: bytes) -> Dict[str, str]:
+        lines = data.decode('utf-8').replace('\r', '\n').split('\n')
+        lines = [line[1:-1] for line in lines if line.startswith('#') and line.endswith(';')]
+        lines = [line for line in lines if ':' in line]
+
+        infodict = {}  # type: Dict[str, str]
+        for line in lines:
+            section, value = line.split(':', 1)
+
+            if not (infodict.get('credit') and section == 'CREDIT'): # ignore subsequent #CREDIT tags
+                infodict[section.lower()] = value
+
+        return infodict
+
+    def __get_notesections(self, data: bytes) -> Dict[str, Dict[str, Any]]:
+        def get_single_line_tag_val(line: str) -> str:
+            return line.strip().split(':')[1][:-1]
+
+        lines = data.decode('utf-8').replace('\r\n', '\n').replace('\r', '\n').split('\n')
+        lines.append('')
+
+        # Line number for error reasons
+        lineno = 1
+
+        # All finished parsed sections
+        sections = {}  # type: Dict[str, Dict[str, Any]]
+
+        # Data we're building up about the current section
+        cursection = {}  # type: Dict[str, Any]
+
+
+        # Whether we're in a section or not.
+        section = False
+
+        # Whether we're in the #NOTES section which contains the measures
+        notes_section = False
+
+        # Whether this section is actually a section we can safely ignore
+        ignorable_section = False
+
+        # The names of the section metadata based on the above line.
+        sectionnames = ['style', 'author', 'difficulty', 'rating']
+
+        # The line number that started the current section.
+        sectionstart = 0
+
+        # The measure data for the current section.
+        sectiondata = []  # type: List[Tuple[int, str]]
+
+        for line in lines:
+            all_sections = ['#LABELS', '#BGCHANGES', '#NOTEDATA', '#NOTES']
+
+            # ignore sections that start with these
+            other_sections = ['#LABELS', '#BGCHANGES']
+            for ignore_section in other_sections:
+                if line.startswith(ignore_section):
+                    print('ignoring', ignore_section)
+                    section = True
+                    ignorable_section = True
+                    # other_sections.remove(ignore_section)
+
+            # See if we should start parsing a notedata section (metadata + notes)
+            if line.strip() == '#NOTEDATA:;':
+                print("beginning #NOTEDATA @", lineno)
+                if section:
+                    raise Exception(
+                        'Found unexpected NOTEDATA section on line {} inside existing section starting on line {}!'.format(lineno, sectionstart)
+                    )
+                section = True
+                sectionstart = lineno
+                cursection = {}
+                sectiondata = []
+
+            # currently in a section, building metadata
+            if section and not ignorable_section:
+                # Either measure data or garbage we care nothing about
+                # Filter out some garbage at least
+                if notes_section and \
+                   not line.strip().startswith('//') and \
+                   not line.strip().startswith(';') and \
+                   not line.strip().startswith(','):
+                    sectiondata.append((lineno, line))
+
+                # abort parsing this section if it's not for museca
+                if line.strip().startswith('#STEPSTYPE'):
+                    cursection['style'] = get_single_line_tag_val(line)
+                if line.strip().startswith('#DIFFICULTY'):
+                    cursection['difficulty'] = get_single_line_tag_val(line)
+                if line.strip().startswith('#METER'):
+                    cursection['rating'] = get_single_line_tag_val(line)
+                if line.strip().startswith('#CREDIT'):
+                    # #CREDIT inside of a #NOTEDATA section maps to 'author'/'effected_by'
+                    # The top-level #CREDIT is used for 'illustrator'!
+                    cursection['author'] = get_single_line_tag_val(line)
+                if line.strip().startswith('#NOTES'):
+                    print("beginning #NOTES @", lineno, cursection)
+                    notes_section = True
+
+            # See if we ended a section.
+            if line.strip() == ';':
+                if not section:
+                    raise Exception(
+                        'Found spurious end section on line {}!'.format(lineno)
+                    )
+
+                print("ending section @", lineno, cursection)
+
+                section = False
+                notes_section = False
+                ignorable_section = False
+                cursection['data'] = sectiondata
+                if cursection.get('difficulty'):
+                    sections[cursection['difficulty'].lower()] = cursection
+
+            lineno = lineno + 1
+
+        return sections
+
+    def __get_events(self, difficulty: str, notedetails: Dict[str, Any]) -> Optional[List[Dict[str, int]]]:
+        # Make sure we can parse the final measure
+        if notedetails['data']:
+            notedetails['data'].append((notedetails['data'][-1][0] + 1, ','))
+
+        # Parse out BPM, convert to milliseconds
+        bpms = sorted(
+            [(ts * 1000.0, bpm) for (ts, bpm) in self.bpms],
+            key=lambda b: b[0]
+        )
+
+        # TODO: parse labels, we kinda need those for grafica sections again
+        # Parse out labels, convert to milliseconds
+        # labels = sorted(
+        #     [(ts * 1000.0, label) for (ts, label) in self.labels],
+        #     key=lambda l: l[0]
+        # )
+        # print(labels)
+
+        # Given a current time in milliseconds, return the BPM at the start of that
+        # measure.
+        def get_cur_bpm(cts: float) -> float:
+            for (ts, bpm) in bpms:
+                if cts >= ts:
+                    return bpm
+            raise Exception('Can\'t determine BPM!')
+
+        # Parse out the chart, one measure at a time.
+        curmeasure = []  # type: List[Tuple[int, str]]
+        events = []  # type: List[Dict[str, int]]
+        pending_events = []  # type: List[Tuple[int, Dict[str, int]]]
+
+        # The time at the beginning of the measure, in milliseconds
+        curtime = float(self.metadata.get('offset', '0.0')) * 1000.0
+
+        def event(kind: int, lane: int, start: float, end: float) -> Dict[str, int]:
+            return {
+                'kind': kind,
+                'lane': lane,
+                'start': int(start),
+                'end': int(end),
+            }
+
+        def parse_measure(curtime: float, measure: List[Tuple[int, str]]) -> float:
+            # First, get the BPM of this measure, and the divisor for the measure.
+            bpm = get_cur_bpm(curtime)
+            notes_per_measure = len(measure)
+
+            # Measures are 4/4 time, so figure out what one measure costs time-wise
+            seconds_per_beat = 60.0/bpm
+            seconds_per_measure = seconds_per_beat * 4.0
+
+            # Now, scale so we know how many seconds are taken up per tick in this
+            # measure.
+            ms_per_note = (seconds_per_measure / notes_per_measure) * 1000.0
+
+            # Also determine standard quarter-note spacing so we can lay out measure markers
+            ms_per_marker = (seconds_per_measure / 4) * 1000.0
+
+            # First, lets output the measure markers
+            events.append(event(
+                Constants.EVENT_KIND_MEASURE_MARKER,
+                Constants.EVENT_KIND_MEASURE_MARKER,
+                curtime,
+                curtime,
+            ))
+            events.append(event(
+                Constants.EVENT_KIND_BEAT_MARKER,
+                Constants.EVENT_KIND_BEAT_MARKER,
+                curtime + ms_per_marker,
+                curtime + ms_per_marker,
+            ))
+            events.append(event(
+                Constants.EVENT_KIND_BEAT_MARKER,
+                Constants.EVENT_KIND_BEAT_MARKER,
+                curtime + ms_per_marker * 2,
+                curtime + ms_per_marker * 2,
+            ))
+            events.append(event(
+                Constants.EVENT_KIND_BEAT_MARKER,
+                Constants.EVENT_KIND_BEAT_MARKER,
+                curtime + ms_per_marker * 3,
+                curtime + ms_per_marker * 3,
+            ))
+
+            # Now, lets parse out the notes for each note in the measure.
+            for (lineno, measurestring) in measure:
+                mset = measurestring.strip()
+                if len(mset) > 0 and len(mset) != len(Constants.SM_LANES):
+                    raise Exception('Invalid measure data on line {}!'.format(lineno))
+
+                # if a mine is found, ignore mines anywhere else on the line
+                storm_ended = False
+
+                ## TRULY WHERE IT BEGINS ##
+                ## ...and also truly where it needs to be refactored ##
+                for msc_lane, sm_lanes in enumerate(Constants.MSC_LANES):
+                    # used for event pushes at the very end of the loop
+                    event_type = None
+
+                    # hold is starting, push to pending_events instead
+                    is_pending = False
+
+                    # hold is ending, check pending_events and push an event
+                    resolving_pending = False
+
+                    # note data for this channel: ['1', '0', '0']
+                    # (or just a single ['0'] for pedal lane)
+                    note_data = [mset[x] for x in sm_lanes]
+
+                    # normal lane lookups across all channels
+                    if msc_lane < 5:
+                        # check mines first for a storm end
+                        if Constants.SM_NOTE_MINE in note_data and not storm_ended:
+                            found = False
+                            for i in range(len(pending_events)):
+                                if (
+                                    pending_events[i][1]['kind'] in Constants.EVENT_CATEGORY_LARGE_SPINNERS and pending_events[i][1]['lane'] == msc_lane
+                                ):
+                                    # Found start, transfer it
+                                    pending_events[i][1]['end'] = int(curtime)
+                                    events.append(pending_events[i][1])
+                                    del pending_events[i]
+                                    storm_ended = True
+
+                                    found = True
+                                    break
+
+                            if not found:
+                                raise Exception('End spin note with no start spin found for lane {} on line {}!'.format(msc_lane, lineno))
+
+                        # normal note/spin processing
+                        tap = note_data[0]
+                        spins = note_data[1:]
+
+                        # normal notes are straightforward
+                        if tap == Constants.SM_NOTE_TAP:
+                            event_type = Constants.EVENT_KIND_NOTE
+                            events.append(event(
+                                event_type,
+                                msc_lane,
+                                curtime,
+                                curtime,
+                            ))
+                        elif tap == Constants.SM_NOTE_HOLD_START:
+                            event_type = Constants.EVENT_KIND_HOLD
+                            is_pending = True
+                            pending_events.append((
+                                lineno,
+                                event(
+                                    event_type,
+                                    msc_lane,
+                                    curtime,
+                                    curtime,
+                                )
+                            ))
+                        elif tap == Constants.SM_NOTE_HOLD_END:
+                            resolving_pending = True
+                            found = False
+                            for i in range(len(pending_events)):
+                                if (
+                                    pending_events[i][1]['kind'] == Constants.EVENT_KIND_HOLD and
+                                    pending_events[i][1]['lane'] == msc_lane
+                                ):
+                                    # Found start, transfer it
+                                    pending_events[i][1]['end'] = int(curtime)
+                                    events.append(pending_events[i][1])
+                                    del pending_events[i]
+
+                                    found = True
+                                    break
+
+                            if not found:
+                                raise Exception('End hold note with no start hold found for lane {} on line {}!'.format(msc_lane, lineno))
+                        elif tap not in Constants.SM_NOTES:
+                            raise Exception('Unknown normal note type {} for lane {} on line {}!'.format(tap, msc_lane, lineno))
+
+                        # both spin lanes have a tap/hold-start, non-directional spin detected
+                        if all([(x in [Constants.SM_NOTE_TAP, Constants.SM_NOTE_HOLD_START]) for x in spins]):
+                            if Constants.SM_NOTE_HOLD_START in spins:
+                                # NOTE: we actually don't care about hold ends in the spin channels at all
+                                # but this is still marked is_pending until a mine ends it
+                                event_type = Constants.EVENT_KIND_LARGE_SPINNER
+                                is_pending = True
+                                pending_events.append((
+                                lineno,
+                                event(
+                                    event_type,
+                                    msc_lane,
+                                    curtime,
+                                    curtime,
+                                )
+                            ))
+                            else: # both spin items are taps
+                                event_type = Constants.EVENT_KIND_SMALL_SPINNER
+                                events.append(event(
+                                    event_type,
+                                    msc_lane,
+                                    curtime,
+                                    curtime,
+                                ))
+                        else:
+                            invalid_note_found = False
+                            if spins[0] != Constants.SM_NOTE_NONE: # spin left
+                                if spins[0] == Constants.SM_NOTE_TAP:
+                                    event_type = Constants.EVENT_KIND_SMALL_SPINNER_LEFT
+                                    events.append(event(
+                                        event_type,
+                                        msc_lane,
+                                        curtime,
+                                        curtime,
+                                    ))
+                                elif spins[0] == Constants.SM_NOTE_HOLD_START:
+                                    event_type = Constants.EVENT_KIND_LARGE_SPINNER_LEFT
+                                    is_pending = True
+                                    pending_events.append((
+                                        lineno,
+                                        event(
+                                            event_type,
+                                            msc_lane,
+                                            curtime,
+                                            curtime,
+                                        )
+                                    ))
+                                elif spins[0] not in Constants.SM_NOTES:
+                                    invalid_note_found = True
+                            elif spins[1] != Constants.SM_NOTE_NONE: # spin right
+                                if spins[1] == Constants.SM_NOTE_TAP:
+                                    event_type = Constants.EVENT_KIND_SMALL_SPINNER_RIGHT
+                                    events.append(event(
+                                        event_type,
+                                        msc_lane,
+                                        curtime,
+                                        curtime,
+                                    ))
+                                elif spins[1] == Constants.SM_NOTE_HOLD_START:
+                                    event_type = Constants.EVENT_KIND_LARGE_SPINNER_RIGHT
+                                    is_pending = True
+                                    pending_events.append((
+                                        lineno,
+                                        event(
+                                            event_type,
+                                            msc_lane,
+                                            curtime,
+                                            curtime,
+                                        )
+                                    ))
+                                elif spins[1] not in Constants.SM_NOTES:
+                                    invalid_note_found = True
+
+                            if invalid_note_found:
+                                raise Exception('Unknown spin note type {} for lane {} on line {}!'.format(spins, msc_lane, lineno))
+
+                    # pedal lane is the last index in this list,
+                    # only accepts hold events
+                    elif msc_lane == 5:
+                        if note_data[0] == Constants.SM_NOTE_HOLD_START:   # pedal start
+                            event_type = Constants.EVENT_KIND_HOLD
+                            is_pending = True
+                            pending_events.append((
+                                lineno,
+                                event(
+                                    event_type,
+                                    msc_lane,
+                                    curtime,
+                                    curtime,
+                                )
+                            ))
+                        elif note_data[0] == Constants.SM_NOTE_HOLD_END: # pedal end
+                            resolving_pending = True
+                            found = False
+                            for i in range(len(pending_events)):
+                                if (
+                                    pending_events[i][1]['kind'] == Constants.EVENT_KIND_HOLD and
+                                    pending_events[i][1]['lane'] == msc_lane
+                                ):
+                                    # Found start, transfer it
+                                    pending_events[i][1]['end'] = int(curtime)
+                                    events.append(pending_events[i][1])
+                                    del pending_events[i]
+
+                                    found = True
+                                    break
+
+                            if not found:
+                                raise Exception('End hold note with no start hold found for lane {} on line {}!'.format(msc_lane, lineno))
+                        elif note_data[0] in [Constants.SM_NOTE_TAP, Constants.SM_NOTE_MINE]:
+                            raise Exception('Invalid note type {} for foot pedal on line {}!'.format(note_data[0], lineno))
+
+                    else:
+                        raise Exception('Note data {} for unknown lane {} on line {}!'.format(note_data, msc_lane, lineno))
+
+                    # if is_pending:
+
+                    # if resolving_pending:
+                    #     found = False
+                    #     for i in range(len(pending_events)):
+                    #         if (
+                    #             pending_events[i][1]['kind'] == Constants.EVENT_KIND_HOLD and
+                    #             pending_events[i][1]['lane'] == msc_lane
+                    #         ):
+                    #             pending_events[i][1]['end'] = int(curtime)
+                    #             events.append(pending_events[i][1])
+                    #             del pending_events[i]
+
+                    #             found = True
+                    #             break
+
+                    #     if not found:
+                    #         raise Exception('End hold note with no start hold found for lane {} on line {}!'.format(msc_lane, lineno))
+
+                # Move ourselves forward past this time.
+                curtime = curtime + ms_per_note
+
+            # Finally, update our time
+            return curtime
+
+        for (lineno, line) in notedetails['data']:
+            if line.strip().startswith(','):
+                # Parse out current measure
+                curtime = parse_measure(curtime, curmeasure)
+                curmeasure = []
+            else:
+                curmeasure.append((lineno, line))
+
+        for (lineno, evt) in pending_events:
+            if evt['kind'] not in Constants.EVENT_CATEGORY_LARGE_SPINNERS:
+                raise Exception('Note started on line {} for lane {} is missing end marker!'.format(lineno, evt['lane'] + 1))
+
+        # Events can be generated out of order, so lets sort them!
+        events = sorted(
+            events,
+            key=lambda event: event['start'],
+        )
+
+        return events
+
+    @property
+    def bpms(self) -> List[Tuple[float, float]]:
+        bpms = []
+        for bpm in self.metadata.get('bpms', '').split(','):
+            if '=' not in bpm:
+                continue
+            time_val, bpm_val = bpm.split('=', 1)
+            timeval = float(time_val)
+            bpmval = float(bpm_val)
+            bpms.append((timeval, bpmval))
+
+        return bpms
+
+    # @property
+    # def labels(self) -> List[Tuple[float, str]]:
+    #     labels = []
+    #     for label in self.metadata.get('labels', '').split(','):
+    #         if '=' not in label:
+    #             continue
+    #         time_val, label_name = label.split('=', 1)
+    #         timeval = float(time_val)
+    #         labels.append((timeval, label_name))
+
+    #     return labels
+
+class XMLv2:
+
+    def __init__(self, chart: Chartv2, chartid: int) -> None:
+        self.__chart = chart
+        self.__id = chartid
+
+    def get_notes(self, difficulty: str) -> bytes:
+        # Grab the parsed event data for this difficulty.
+        events = self.__chart.events.get(difficulty)
+
+        if events is None:
+            return b''
+
+        # Parse out BPM, convert to milliseconds
+        bpms = sorted(
+            [(ts * 1000.0, bpm) for (ts, bpm) in self.__chart.bpms],
+            key=lambda b: b[0]
+        )
+
+        # Write out the chart
+        chart = minidom.Document()
+        root = chart.createElement('data')
+        chart.appendChild(root)
+
+        def element(parent: Any, name: str, value: Optional[str]=None) -> Any:
+            element = chart.createElement(name)
+            parent.appendChild(element)
+
+            if value is not None:
+                text = chart.createTextNode(value)
+                element.appendChild(text)
+
+            return element
+
+        # Chart info
+        smf_info = element(root, 'smf_info')
+        element(smf_info, 'ticks', '480').setAttribute('__type', 's32')
+
+        tempo_info = element(smf_info, 'tempo_info')
+
+        # Copy down BPM changes
+        for (timedelta, bpm) in bpms:
+            tempo = element(tempo_info, 'tempo')
+            element(tempo, 'time', str(int(timedelta * 100))).setAttribute('__type', 's32')
+            element(tempo, 'delta_time', '0').setAttribute('__type', 's32')
+            element(tempo, 'val', str(int((60.0 / bpm) * 1000000))).setAttribute('__type', 's32')
+            element(tempo, 'bpm', str(int(bpm * 100))).setAttribute('__type', 's64')
+
+        # We don't currently support signature changes, so none of that here
+        # TODO: support time signature changes
+        sig_info = element(smf_info, 'sig_info')
+        signature = element(sig_info, 'signature')
+        element(signature, 'time', '0').setAttribute('__type', 's32')
+        element(signature, 'delta_time', '0').setAttribute('__type', 's32')
+        element(signature, 'num', '4').setAttribute('__type', 's32')
+        element(signature, 'denomi', '4').setAttribute('__type', 's32')
+
+        # Output parsed events
+        for parsedevent in events:
+            kind = parsedevent['kind']
+            lane = parsedevent['lane']
+
+            if kind in [
+                Constants.EVENT_KIND_MEASURE_MARKER,
+                Constants.EVENT_KIND_BEAT_MARKER,
+                Constants.EVENT_KIND_GRAFICA_SECTION_START,
+                Constants.EVENT_KIND_GRAFICA_SECTION_END,
+            ]:
+                # Special case, the lane doesn't matter for these as they're global.
+                lane = kind
+
+            if kind in [
+                Constants.EVENT_KIND_HOLD,
+                Constants.EVENT_KIND_LARGE_SPINNER,
+                Constants.EVENT_KIND_LARGE_SPINNER_LEFT,
+                Constants.EVENT_KIND_LARGE_SPINNER_RIGHT,
+            ]:
+                # Special case, holds and spins use 6-10 instead of 0-4. They still
+                # use 5 for foot pedal though because that can only be a hold.
+                if lane >= 0 and lane <= 4:
+                    lane = 6 + lane
+
+            eventnode = element(root, 'event')
+            element(eventnode, 'stime_ms', str(parsedevent['start'])).setAttribute('__type', 's64')
+            element(eventnode, 'etime_ms', str(parsedevent['end'])).setAttribute('__type', 's64')
+            element(eventnode, 'type', str(lane)).setAttribute('__type', 's32')
+            element(eventnode, 'kind', str(kind)).setAttribute('__type', 's32')
+
+        # Return the chart data.
+        return chart.toprettyxml(indent="  ").encode('ascii')
+
+    def __add_metadata_to_document(
+        self,
+        music_data: minidom.Document,
+    ) -> None:
+        # Find MDB node
+        mdb_nodes = music_data.getElementsByTagName('mdb')
+        if len(mdb_nodes) != 1:
+            raise Exception('Invalid XML file layout!')
+        mdb = mdb_nodes[0]
+
+        # Grab info
+        infodict = self.__chart.metadata
+
+        # Grab notes sections
+        notedetails = self.__chart.notes
+
+        # Parse out BPM
+        bpms = self.__chart.bpms
+
+        # Grab max and min BPM
+        maxbpm = max([bpm for (_, bpm) in bpms])
+        minbpm = min([bpm for (_, bpm) in bpms])
+
+        def element(parent: Any, name: str, value: Optional[str]=None) -> Any:
+            element = music_data.createElement(name)
+            parent.appendChild(element)
+
+            if value is not None:
+                text = music_data.createTextNode(value)
+                element.appendChild(text)
+
+            return element
+
+        # Create a single child with the right music ID
+        music = element(mdb, 'music')
+        music.setAttribute('id', str(self.__id))
+
+        # Create info section for metadata
+        info = element(music, 'info')
+
+        # Copypasta into info the various data we should have
+        element(info, 'label', str(self.__id))
+        element(info, 'title_name', infodict.get('title', ''))
+        element(info, 'title_yomigana', infodict.get('titletranslit', ''))
+        element(info, 'artist_name', infodict.get('artist', ''))
+        element(info, 'artist_yomigana', infodict.get('artisttranslit', ''))
+        element(info, 'ascii', infodict.get('subtitletranslit', 'dummy'))
+        element(info, 'bpm_min', str(int(minbpm * 100))).setAttribute('__type', 'u32')
+        element(info, 'bpm_max', str(int(maxbpm * 100))).setAttribute('__type', 'u32')
+        element(info, 'distribution_date', datetime.date.strftime(datetime.datetime.now(), "%Y%m%d")).setAttribute('__type', 'u32')  # type: ignore
+
+        # TODO: Figure out what some of these should be
+        element(info, 'volume', '75').setAttribute('__type', 'u16')
+        element(info, 'bg_no', '0').setAttribute('__type', 'u16')
+        element(info, 'genre', '16').setAttribute('__type', 'u8')
+        element(info, 'is_fixed', '1').setAttribute('__type', 'u8')
+        element(info, 'version', '1').setAttribute('__type', 'u8')
+        element(info, 'demo_pri', '-2').setAttribute('__type', 's8')
+        element(info, 'world', '0').setAttribute('__type', 'u8')
+        element(info, 'tier', '-2').setAttribute('__type', 's8')
+        element(info, 'license', infodict.get('license', ''))
+        element(info, 'vmlink_phase', '0').setAttribute('__type', 's32')
+        element(info, 'inf_ver', '0').setAttribute('__type', 'u8')
+
+        # Create difficulties section
+        difficulty = element(music, 'difficulty')
+        for diffval in ['easy', 'medium', 'hard', 'expert']:
+            root = element(difficulty, diffval)
+            if diffval != 'expert':
+                details = notedetails.get(diffval, {})
+            else:
+                details = {}  # type: Dict[str, str]
+
+            element(root, 'difnum', details.get('rating', '0')).setAttribute('__type', 'u8')
+            element(root, 'illustrator', infodict.get('credit', ''))
+            element(root, 'effected_by', details.get('author', ''))
+            element(root, 'price', '-1').setAttribute('__type', 's32')
+            element(root, 'limited', '1' if (diffval == 'expert' or  details.get('rating', '0') == '0') else '3').setAttribute('__type', 'u8')
+
+    def get_metadata(self) -> bytes:
+        # Create root document
+        music_data = minidom.Document()
+        mdb = music_data.createElement('mdb')
+        music_data.appendChild(mdb)
+
+        # Add our info to the empty doc.
+        self.__add_metadata_to_document(music_data)
+
+        return music_data.toprettyxml(indent="  ", encoding='shift_jisx0213').replace(b'shift_jisx0213', b'shift-jis')
+
+    def update_metadata(self, old_data: bytes) -> bytes:
+        # Parse old root document, being sure to recognize the encoding lie
+        try:
+            datastr = old_data.decode('utf-8')
+            encoding = 'utf-8'
+        except UnicodeDecodeError:
+            try:
+                datastr = old_data.decode('shift_jisx0213')
+                encoding = 'shift_jisx0213'
+            except UnicodeDecodeError:
+                raise Exception('Unable to parse exising XML data!')
+
+        music_data = minidom.parseString(datastr)
+        mdb = music_data.createElement('mdb')
+
+        # First, find and delete any music entries matching our ID
+        for node in music_data.getElementsByTagName('music'):
+            idattr = node.attributes.get('id')
+            if idattr is not None:
+                idval = str(idattr.value)
+                if idval == str(self.__id):
+                    parent = node.parentNode
+                    parent.removeChild(node)
+
+        # Now, add our info to the updated doc
+        self.__add_metadata_to_document(music_data)
+
+        newdata = music_data.toprettyxml(indent="  ", encoding=encoding).replace(encoding.encode('ascii'), b'shift-jis')
+
+        # For some reason, minidom loves adding tons of whitespace, so lets
+        # hack it back out.
+        return b'\n'.join([
+            line for line in newdata.split(b'\n')
+            if len(line.strip()) > 0
+        ])

--- a/chartv2.py
+++ b/chartv2.py
@@ -163,7 +163,9 @@ class Chartv2:
 
     def __get_metadata(self, data: bytes) -> Dict[str, str]:
         lines = data.decode('utf-8').replace('\r', '\n').split('\n')
-        lines = [line[1:-1] for line in lines if line.startswith('#') and line.endswith(';')]
+        lines = [line[1:-1] for line in lines if line.startswith('#') and line.endswith(';') and \
+        # ignore tags that can potentially contain multiple values but only contain 1
+                 not (line.startswith('#BPMS') or line.startswith('#LABELS'))]
         lines = [line for line in lines if ':' in line]
 
         infodict = {}  # type: Dict[str, str]

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ In the above command, a chart for Novice (Green), Advanced (Yellow), and Exhaust
 
 ## About This Fork
 
-This fork is designed to be used in conjunction with [a fork of StepMania 5.2 that adds a new ``museca-single`` game mode](https://github.com/theKeithD/sm2museca). This mode defines a 16-lane single player mode, rather than a 16-lane double play mode like the ones offered by ``bm`` and ``techno``. A noteskin is provided that helps better visualize the spin lanes on top of the normal lanes and should result in quicker and easier chart creation.
+This fork is designed to be used in conjunction with [a fork of StepMania 5.2 that adds a new ``museca-single`` game mode](https://github.com/theKeithD/stepmania-musecaeditor). This mode defines a 16-lane single player mode, rather than a 16-lane double play mode like the ones offered by ``bm`` and ``techno``. A noteskin is provided that helps better visualize the spin lanes on top of the normal lanes and should result in quicker and easier chart creation.
 
 _(Binaries to be provided soon)_
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Note that the game supports time signatures other than 4/4 but the converter doe
 ### More chart format
 Each chart begins with a `#NOTEDATA:;` line. The following tags after `#NOTEDATA:;` are used by the converter:
 - ``#STEPSTYPE`` - The only supported type is ``museca-single``.
-- ``#CREDIT`` - The author of the chart, AKA your handle. Not to be confused with the ``#CREDIT``. Note that this doesn't actually get displayed anywhere, and usually even tends to be "``dummy``"
+- ``#CREDIT`` - The author of the chart, AKA your handle. Not to be confused with the ``#CREDIT`` one level up in ``#NOTESDATA:;``. Note that this doesn't actually get displayed anywhere, and usually tends to be "``dummy``".
 - ``#DIFFICULTY`` - One of the following three supported difficulties: ``Easy``, ``Medium``, or ``Hard``.
 - ``#METER`` - The difficulty rating, as a value from 1-15 inclusive.
 - ``#NOTES`` - The actual note data, which will continue to be parsed until a line with only a  ``;`` on it is encountered.

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,13 @@ In the above command, a chart for Novice (Green), Advanced (Yellow), and Exhaust
 
 ## About This Fork
 
-This fork is designed to be used in conjunction with [https://github.com/theKeithD/sm2museca](a fork of StepMania 5.2 that adds a new ``museca-single`` game mode). This mode defines a 16-lane single player mode, rather than a 16-lane double play mode like the ones offered by ``bm`` and ``techno``.
+This fork is designed to be used in conjunction with [a fork of StepMania 5.2 that adds a new ``museca-single`` game mode](https://github.com/theKeithD/sm2museca). This mode defines a 16-lane single player mode, rather than a 16-lane double play mode like the ones offered by ``bm`` and ``techno``. A noteskin is provided that helps better visualize the spin lanes on top of the normal lanes and should result in quicker and easier chart creation.
 
 _(Binaries to be provided soon)_
 
 ## Dependencies
 
-The following dependencies are required to run this conversion software:
+The following external dependencies are required to run this conversion software:
 
 - ffmpeg - Used to convert various audio formats to the ADPCM format required by MÚSECA.
 - sox - Used to create preview clips.
@@ -31,23 +31,23 @@ Note that the game supports time signatures other than 4/4 but the converter doe
 
 ## Header Tags
 
-* ``TITLE`` - The title of the song as it shows in-game. This can be any unicode characters, including english, kana or kanji.
-* ``TITLETRANSLIT`` - The title of the song as sounded out in katakana, with dakuten and in half-width. This is used for title sort. There are converters which take any english and give you the katakana, and converters that go from full-width to half-width katakana. Use them!
-* ``ARTIST`` - The artist of the song as it shows in-game. This can be any unicode characters, including english, kana or kanji.
-* ``ARTISTTRANSLIT`` - The artist of the song as sounded out in katakana, with dakuten and in half-width. This is used for artist sort. There are converters which take any english and give you the katakana, and converters that go from full-width to half-width katakana. Use them!
-* ``SUBTITLETRANSLIT`` - This maps to the ``ascii`` element in music-info.xml, and defaults to "``dummy``". Can (and should) be left blank.
+* ``TITLE`` - The title of the song as it shows in-game. This can include all sorts of characters, including english, kana or kanji. Various accented latin characters may not render correctly due to particulars about how the game handles certain character sets, though.
+* ``TITLETRANSLIT`` - The title of the song as sounded out, written in half-width katakana (dakuten allowed). This is used for title sort. There are converters which take any english and give you the katakana, and converters that go from full-width to half-width katakana. Use them!
+* ``ARTIST`` - The artist of the song as it shows in-game. This can include all sorts of characters, including english, kana or kanji. Various accented latin characters may not render correctly due to particulars about how the game handles certain character sets, though.
+* ``ARTISTTRANSLIT`` - The artist of the song as sounded out, written in half-width katakana (dakuten allowed). This is used for artist sort. There are converters which take any english and give you the katakana, and converters that go from full-width to half-width katakana. Use them!
+* ``SUBTITLETRANSLIT`` - Can (and should) be omitted. This maps to the ``ascii`` element in music-info.xml, and defaults to "``dummy``" if no value is provided.
 * ``MUSIC`` - Path to an audio file to be converted. Use any format supported by ffmpeg.
 * ``SAMPLESTART`` - Number of seconds into the above music to start the preview. The converter will auto-fade in and convert to a preview song.
-* ``SAMPLELENGTH`` - Number of seconds after the start to continue playing the preview before cutting off. The game tends to use 10-second previews, so its wise to stick with that.
+* ``SAMPLELENGTH`` - Number of seconds after the start to continue playing the preview before cutting off. The game tends to use 10-second previews, so it's wise to stick with that.
 * ``OFFSET`` - Number of seconds to offset the chart relative to the start of the music. Use this to sync the game to the chart.
-* ``BPMS`` - What BPM the chart is at. For help on this field, please refer to [https://github.com/stepmania/stepmania/wiki/ssc](the .ssc format documentation). It is not a simple number, but instead a comma-separated list of timestamps in seconds paired to a BPM that the song uses at that point.
+* ``BPMS`` - What BPM the chart is at. For help on this field, please refer to [the .ssc format documentation](https://github.com/stepmania/stepmania/wiki/ssc). It is not a simple number, but instead a comma-separated list of timestamps in seconds paired to a BPM that the song uses at that point.
 * ``LICENSE`` - The license owner of the song. Can be left blank.
 * ``CREDIT`` - The illustration artist. Can be left blank.
 
 ### More chart format
 Each chart begins with a `#NOTEDATA:;` line. The following tags after `#NOTEDATA:;` are used by the converter:
 - ``#STEPSTYPE`` - The only supported type is ``museca-single``.
-- ``#CREDIT`` - The author of the chart, AKA your handle. Not to be confused with the ``#CREDIT``
+- ``#CREDIT`` - The author of the chart, AKA your handle. Not to be confused with the ``#CREDIT``. Note that this doesn't actually get displayed anywhere, and usually even tends to be "``dummy``"
 - ``#DIFFICULTY`` - One of the following three supported difficulties: ``Easy``, ``Medium``, or ``Hard``.
 - ``#METER`` - The difficulty rating, as a value from 1-15 inclusive.
 - ``#NOTES`` - The actual note data, which will continue to be parsed until a line with only a  ``;`` on it is encountered.
@@ -104,7 +104,7 @@ There is 1 pedal lane, and then 3 channels of 5 lanes each.
 - Grafica gates are planned to be events within #LABELS.
   1. This will require the converter to parse the #LABELS list.
   2. And then perform some basic sanity checks. (START -> END -> START -> END -> START -> END)
-    - The label names will follow a pattern of ``GRAFICA_n_[START|END]``, where ``[n]`` is a value from 1-3 inclusive.
+    - The label names will follow a pattern of ``GRAFICA_n_[START|END]``, where ``n`` is a value from 1-3 inclusive.
   3. And then convert the beat numbers used into milliseconds.
   4. And then push these to the events list.
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,9 @@ In the above command, a chart for Novice (Green), Advanced (Yellow), and Exhaust
 
 This fork is designed to be used in conjunction with [a fork of StepMania 5.2 that adds a new ``museca-single`` game mode](https://github.com/theKeithD/stepmania-musecaeditor). This mode defines a 16-lane single player mode, rather than a 16-lane double play mode like the ones offered by ``bm`` and ``techno``. A noteskin is provided that helps better visualize the spin lanes on top of the normal lanes and should result in quicker and easier chart creation.
 
-_(Binaries to be provided soon)_
+Windows binaries for this StepMania 5.2 fork are available as a .zip or .exe installer:
+- **.zip**: https://ortlin.de/i/msc/StepMania-5.2-git-edbed30b62-win32.zip
+- **.exe installer**: https://ortlin.de/i/msc/StepMania-5.2-git-edbed30b62-win32.exe
 
 ## Dependencies
 
@@ -110,6 +112,7 @@ There is 1 pedal lane, and then 3 channels of 5 lanes each.
 ### TODO
 - Chart-specific ``#BPMS`` and ``#LABELS``.
     - This can be accomplished by using Step Timing mode instead of Song Timing mode in SM5.
+    - Right now, using Step Timing at all will break the converter.
     - The parser will need to ignore many more sections while within ``#NOTEDATA``:
         - #TIMESIGNATURESEGMENT
         - #TICKCOUNTS
@@ -121,24 +124,26 @@ There is 1 pedal lane, and then 3 channels of 5 lanes each.
         - This means subsequent values start with ``\n,`` instead of ``,\n`` as it is elsewhere
         - This also means the tag-ending ``;`` always appears on its own line, which differs from how the main song header keeps the final semi-colon on the same line for multi-value tags.
     - Basically, this means reworking the parser quite a fair bit.
+- Allow storm end events to also be pulled in from ``#LABELS``, which will remove a limitation in this chart format
+- Adjust output file locations to put chart/audio data in one folder, and music-info.xml in another folder?
 
 ## Example chart
 
 Below is an example chart, which includes a few measures showcasing a handful of events:
 
     #VERSION:0.83;
-    #TITLE:双翼の独奏歌;
-    #ARTIST:ダークイルミネイト;
-    #TITLETRANSLIT:ｿｳﾖｸﾉｱﾘｱ;
-    #ARTISTTRANSLIT:ﾀﾞｰｸｲﾙﾐﾈｲﾄ;
-    #CREDIT:BANDAI NAMCO;
+    #TITLE:Test Song;
+    #ARTIST:Test;
+    #TITLETRANSLIT:ﾃｽﾄｿﾝｸﾞｸ;
+    #ARTISTTRANSLIT:ﾃｽﾄ;
+    #CREDIT:ILLUSTRATOR;
     #BANNER:banner.jpg;
-    #BACKGROUND:end.jpg;
+    #BACKGROUND:bg.jpg;
     #DISCIMAGE:;
-    #MUSIC:aria.wav;
+    #MUSIC:test.wav;
     #OFFSET:0.000000;
     #SAMPLESTART:72.680000;
-    #SAMPLELENGTH:13.083000;
+    #SAMPLELENGTH:10.000000;
     #SELECTABLE:YES;
     #BPMS:0.000=170.000;
     #TIMESIGNATURES:0.000=4=4;
@@ -259,7 +264,7 @@ Below is an example chart, which includes a few measures showcasing a handful of
 
     [--snip--]
 
-    ,  // measure 77
+    ,  // measure 77 (this is 2 storm objects layered on top of 2 hold starts, don't do this!)
     2200022000110002
     3000003000000003
     0000000000000000

--- a/ssc2museca.py
+++ b/ssc2museca.py
@@ -1,0 +1,143 @@
+import argparse
+import datetime
+import os
+import sys
+
+from typing import Dict, Any, List, Tuple, Optional
+from xml.dom import minidom  # type: ignore
+
+from chartv2 import Chartv2, XMLv2
+from audio import TwoDX, ADPCM
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="A utility to convert 16-lane StepMania charts (.ssc format) to Museca format.")
+    parser.add_argument(
+        "file",
+        metavar="FILE",
+        help=".mu file to convert to Museca format.",
+        type=str,
+    )
+    parser.add_argument(
+        "id",
+        metavar="ID",
+        help="ID to assign this song.",
+        type=int,
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        help="Directory to place files in. Defaults to current directory.",
+        default='.',
+    )
+    parser.add_argument(
+        "-x",
+        "--update-xml",
+        help="Location of music database XML file to update. If not specified, "
+             "a new one will be created containing just the data for this file.",
+        default=None,
+    )
+
+    args = parser.parse_args()
+    root = args.directory
+    if root[-1] != '/':
+        root = root + '/'
+    root = os.path.realpath(root)
+    os.makedirs(root, exist_ok=True)
+
+    fp = open(args.file, 'rb')
+    data = fp.read()
+    fp.close()
+
+    print('Parsing chart data...')
+
+    # First, parse out the chart and get the XML writer ready.
+    chart = Chartv2(data)
+    xml = XMLv2(chart, args.id)
+
+    print('Outputting XML...')
+
+    if args.update_xml is not None:
+        # First, update the metadata file with the info from this chart.
+        fp = open(args.update_xml, "rb")
+        data = fp.read()
+        fp.close()
+        fp = open(args.update_xml, "wb")
+        fp.write(xml.update_metadata(data))
+        fp.close()
+    else:
+        # First, write out a metadata file, that can be copied into music-info.xml
+        fp = open(os.path.join(root, 'music-info.xml'), 'wb')
+        fp.write(xml.get_metadata())
+        fp.close()
+
+    # Now, write out the chart data - nov/green
+    fp = open(os.path.join(root, '01_{num:04d}_nov.xml'.format(num=args.id)), 'wb')
+    fp.write(xml.get_notes('easy'))
+    fp.close()
+
+    # Now, write out the chart data - adv/yellow
+    fp = open(os.path.join(root, '01_{num:04d}_adv.xml'.format(num=args.id)), 'wb')
+    fp.write(xml.get_notes('medium'))
+    fp.close()
+
+    # Now, write out the chart data - exh/red
+    fp = open(os.path.join(root, '01_{num:04d}_exh.xml'.format(num=args.id)), 'wb')
+    fp.write(xml.get_notes('hard'))
+    fp.close()
+
+    # Should we even attempt inf?
+    # fp = open(os.path.join(root, '01_{num:04d}_inf.xml'.format(num=args.id)), 'wb')
+    # fp.write(xml.get_notes('infinite'))
+    # fp.close()
+
+    # Write out miscelaneous files
+    fp = open(os.path.join(root, '01_{num:04d}.def'.format(num=args.id)), 'wb')
+    fp.write('#define 01_{num:04d}   0\n'.format(num=args.id).encode('ascii'))
+    fp.close()
+    fp = open(os.path.join(root, '01_{num:04d}_prv.def'.format(num=args.id)), 'wb')
+    fp.write('#define 01_{num:04d}_prv   0\n'.format(num=args.id).encode('ascii'))
+    fp.close()
+
+    # Now, if we have an audio file, convert that too
+    musicfile = chart.metadata.get('music')
+    if musicfile is not None:
+        # Make sure we also provided a sample start/offset
+        preview_start = chart.metadata.get('samplestart')
+        preview_length = chart.metadata.get('samplelength')
+
+        if preview_start is None:
+            raise Exception('Music file present but no sample start specified for preview!')
+        sample_start = float(preview_start)
+        if preview_length is None:
+            print('WARNING: No sample length specified, assuming 10 seconds!', file=sys.stderr)
+            sample_length = 10.0
+        else:
+            sample_length = float(preview_length)
+
+        print('Converting audio...')
+
+        adpcm = ADPCM(musicfile, sample_start, sample_length)
+        twodx = TwoDX()
+        twodx.set_name('01_{num:04d}'.format(num=args.id))
+        twodx.write_file('01_{num:04d}_1.wav'.format(num=args.id), adpcm.get_full_data())
+
+        fp = open(os.path.join(root, '01_{num:04d}.2dx'.format(num=args.id)), 'wb')
+        fp.write(twodx.get_new_data())
+        fp.close()
+
+        print('Converting preview...')
+
+        twodx = TwoDX()
+        twodx.set_name('01_{num:04d}_prv'.format(num=args.id))
+        twodx.write_file('01_{num:04d}_prv_1.wav'.format(num=args.id), adpcm.get_preview_data())
+
+        fp = open(os.path.join(root, '01_{num:04d}_prv.2dx'.format(num=args.id)), 'wb')
+        fp.write(twodx.get_new_data())
+        fp.close()
+
+    print('Done!')
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This combined with the StepMania 5.2 fork linked in readme.md greatly enhances the visual charting experience, allowing the use of StepMania for the entire chart authoring process.
The only downside is that 16 lanes is a lot to take in at first, as seen in the screenshot linked here: https://ortlin.de/i/20180520015258.jpg

See the `readme.md` in this branch as well as [the `readme.md` in `stepmania-musecaeditor`](https://github.com/theKeithD/stepmania-musecaeditor#lane-layout-charting-and-design-notes) for more details on the chart format.

Tested and functioning on real hardware, open to suggestions and improvements.
The new converter (`chartv2.py` and `ssc2museca.py`) exists alongside the original converter (`chart.py` and `sm2museca.py`).